### PR TITLE
feat: allowing protobuf 4.X and 5.X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
         python_requires=">=3.7",
-        install_requires=["grpcio~=1.17", "protobuf~=3.19"],
+        install_requires=["grpcio~=1.17", "protobuf>=3.19,<6"],
         package_dir = {"": "src"},
         packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={


### PR DESCRIPTION
Modifying setup.py to align with the rest of the ecosystem. See https://github.com/ansys/ansys-tools-protoc-helper/issues/29#issuecomment-2286076903